### PR TITLE
feat: support of push events for barecheck metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: CI
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
+on: [push]
 
 jobs:
   checks:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   checks:

--- a/dist/index.js
+++ b/dist/index.js
@@ -9932,6 +9932,7 @@ module.exports = { mergeFileLinesWithChangedFiles };
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const github = __nccwpck_require__(5438);
+const core = __nccwpck_require__(2186);
 
 const {
   setProjectMetric,
@@ -9961,6 +9962,7 @@ const getBaseMetric = async () => {
 
   const apiKey = getBarecheckApiKey();
 
+  core.info(`Getting metrics from Barecheck. ref=${ref}, sha=${sha}`);
   const metrics = await getProjectMetric(apiKey, ref, sha);
 
   return metrics;
@@ -9973,6 +9975,9 @@ const sendMetricsToBarecheck = async (coverage) => {
 
   const apiKey = getBarecheckApiKey();
 
+  core.info(
+    `Sending metrics to Barecheck. ref=${ref}, sha=${sha}, coverage=${coverage}`
+  );
   const { projectMetricId } = await setProjectMetric(
     apiKey,
     ref,

--- a/dist/index.js
+++ b/dist/index.js
@@ -9969,7 +9969,7 @@ const getBaseMetric = async () => {
 };
 
 const sendMetricsToBarecheck = async (coverage) => {
-  const { ref: fullRef, sha } = github.context.payload;
+  const { ref: fullRef, sha } = github.context;
 
   const ref = cleanRef(fullRef);
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -10879,7 +10879,6 @@ var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 const core = __nccwpck_require__(2186);
-const github = __nccwpck_require__(5438);
 
 const { checkMinimumRatio } = __nccwpck_require__(3324);
 const { sendSummaryComment } = __nccwpck_require__(7788);
@@ -10934,8 +10933,6 @@ async function main() {
 }
 
 try {
-  // eslint-disable-next-line no-console
-  console.log(github.context);
   main();
 } catch (err) {
   core.info(err);

--- a/dist/index.js
+++ b/dist/index.js
@@ -10064,6 +10064,8 @@ module.exports = {
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const core = __nccwpck_require__(2186);
+const github = __nccwpck_require__(5438);
+
 const getChangedFiles = __nccwpck_require__(397);
 const { uncoveredFileLinesByFileNames } = __nccwpck_require__(3318);
 const { mergeFileLinesWithChangedFiles } = __nccwpck_require__(3257);
@@ -10072,7 +10074,7 @@ const { getShowAnnotations } = __nccwpck_require__(6);
 const showAnnotations = async (compareFileData) => {
   const showAnnotationsInput = getShowAnnotations();
 
-  if (showAnnotationsInput) {
+  if (showAnnotationsInput && github.context.payload.pull_request) {
     core.info("Show annotations feature enabled");
     const changedFiles = await getChangedFiles();
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -10853,6 +10853,7 @@ var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 const core = __nccwpck_require__(2186);
+const github = __nccwpck_require__(5438);
 
 const { checkMinimumRatio } = __nccwpck_require__(3324);
 const { sendSummaryComment } = __nccwpck_require__(7788);
@@ -10907,6 +10908,7 @@ async function main() {
 }
 
 try {
+  console.log(github.context);
   main();
 } catch (err) {
   core.info(err);

--- a/src/features/barecheckApi.js
+++ b/src/features/barecheckApi.js
@@ -36,7 +36,7 @@ const getBaseMetric = async () => {
 };
 
 const sendMetricsToBarecheck = async (coverage) => {
-  const { ref: fullRef, sha } = github.context.payload;
+  const { ref: fullRef, sha } = github.context;
 
   const ref = cleanRef(fullRef);
 

--- a/src/features/barecheckApi.js
+++ b/src/features/barecheckApi.js
@@ -6,8 +6,25 @@ const {
 } = require("../services/barecheckApi");
 const { getBarecheckApiKey } = require("../input");
 
-const getMetricsFromBaseBranch = async () => {
-  const { ref, sha } = github.context.payload.pull_request.base;
+const cleanRef = (fullRef) =>
+  fullRef ? fullRef.replace("refs/heads/", "") : null;
+
+const getBaseMetric = async () => {
+  const {
+    before: baseSha,
+    base_ref: baseRef,
+    ref: currentRef,
+    pull_request: pullRequest
+  } = github.context.payload;
+
+  const ref = cleanRef(baseRef || currentRef);
+
+  const sha = pullRequest ? pullRequest.base.sha : baseSha;
+
+  // # if for some reason base ref, sha cannot be defined just skip comparision part
+  if (!ref || !sha) {
+    return null;
+  }
 
   const apiKey = getBarecheckApiKey();
 
@@ -17,7 +34,9 @@ const getMetricsFromBaseBranch = async () => {
 };
 
 const sendMetricsToBarecheck = async (coverage) => {
-  const { ref, sha } = github.context.payload.pull_request.head;
+  const { ref: fullRef, sha } = github.context.payload;
+
+  const ref = cleanRef(fullRef);
 
   const apiKey = getBarecheckApiKey();
 
@@ -33,5 +52,5 @@ const sendMetricsToBarecheck = async (coverage) => {
 
 module.exports = {
   sendMetricsToBarecheck,
-  getMetricsFromBaseBranch
+  getBaseMetric
 };

--- a/src/features/barecheckApi.js
+++ b/src/features/barecheckApi.js
@@ -1,4 +1,5 @@
 const github = require("@actions/github");
+const core = require("@actions/core");
 
 const {
   setProjectMetric,
@@ -28,6 +29,7 @@ const getBaseMetric = async () => {
 
   const apiKey = getBarecheckApiKey();
 
+  core.info(`Getting metrics from Barecheck. ref=${ref}, sha=${sha}`);
   const metrics = await getProjectMetric(apiKey, ref, sha);
 
   return metrics;
@@ -40,6 +42,9 @@ const sendMetricsToBarecheck = async (coverage) => {
 
   const apiKey = getBarecheckApiKey();
 
+  core.info(
+    `Sending metrics to Barecheck. ref=${ref}, sha=${sha}, coverage=${coverage}`
+  );
   const { projectMetricId } = await setProjectMetric(
     apiKey,
     ref,

--- a/src/features/showAnnotations.js
+++ b/src/features/showAnnotations.js
@@ -1,4 +1,6 @@
 const core = require("@actions/core");
+const github = require("@actions/github");
+
 const getChangedFiles = require("../github/getChangedFiles");
 const { uncoveredFileLinesByFileNames } = require("../lcov");
 const { mergeFileLinesWithChangedFiles } = require("../coverage");
@@ -7,7 +9,7 @@ const { getShowAnnotations } = require("../input");
 const showAnnotations = async (compareFileData) => {
   const showAnnotationsInput = getShowAnnotations();
 
-  if (showAnnotationsInput) {
+  if (showAnnotationsInput && github.context.payload.pull_request) {
     core.info("Show annotations feature enabled");
     const changedFiles = await getChangedFiles();
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ const { sendSummaryComment } = require("./features/sendSummaryComment");
 const { showAnnotations } = require("./features/showAnnotations");
 const {
   sendMetricsToBarecheck,
-  getMetricsFromBaseBranch
+  getBaseMetric
 } = require("./features/barecheckApi");
 
 const { getCoverageFromFile } = require("./services/lcovFile");
@@ -24,7 +24,7 @@ const runFeatures = async (diff, coverage) => {
 // TODO: move to `coverage` service to define priorities from
 // where metrics should be calculated
 const runCodeCoverage = async (coverage, baseFile) => {
-  const baseMetrics = await getMetricsFromBaseBranch();
+  const baseMetrics = await getBaseMetric();
   let baseCoveragePercentage = baseMetrics ? baseMetrics.coverage : 0;
 
   if (!baseCoveragePercentage && baseFile) {

--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,7 @@ async function main() {
 }
 
 try {
+  // eslint-disable-next-line no-console
   console.log(github.context);
   main();
 } catch (err) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 const core = require("@actions/core");
+const github = require("@actions/github");
 
 const { checkMinimumRatio } = require("./features/minimumRatio");
 const { sendSummaryComment } = require("./features/sendSummaryComment");
@@ -53,6 +54,7 @@ async function main() {
 }
 
 try {
+  console.log(github.context);
   main();
 } catch (err) {
   core.info(err);

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 const core = require("@actions/core");
-const github = require("@actions/github");
 
 const { checkMinimumRatio } = require("./features/minimumRatio");
 const { sendSummaryComment } = require("./features/sendSummaryComment");
@@ -54,8 +53,6 @@ async function main() {
 }
 
 try {
-  // eslint-disable-next-line no-console
-  console.log(github.context);
   main();
 } catch (err) {
   core.info(err);

--- a/test/features/barecheckApi.test.js
+++ b/test/features/barecheckApi.test.js
@@ -132,10 +132,8 @@ describe(path, () => {
 
       const github = {
         context: {
-          payload: {
-            ref,
-            sha
-          }
+          ref,
+          sha
         }
       };
 

--- a/test/features/barecheckApi.test.js
+++ b/test/features/barecheckApi.test.js
@@ -2,10 +2,12 @@ const sinon = require("sinon");
 const { assert } = require("chai");
 
 const { importMock } = require("../utils");
+const actionsCoreStub = require("../stubs/actionsCore.stub");
 
 const path = "features/barecheckApi";
 
 const defaultStubValues = {
+  ...actionsCoreStub,
   github: {
     context: {
       payload: {
@@ -30,8 +32,16 @@ const defaultStubValues = {
 const barecheckApiMock = importMock(
   path,
   defaultStubValues,
-  ({ github, getProjectMetric, setProjectMetric, getBarecheckApiKey }) => ({
+  ({
+    github,
+    getProjectMetric,
+    setProjectMetric,
+    getBarecheckApiKey,
+    info,
+    getInput
+  }) => ({
     "@actions/github": github,
+    "@actions/core": { getInput, info },
     "../services/barecheckApi": { getProjectMetric, setProjectMetric },
     "../input": { getBarecheckApiKey }
   })


### PR DESCRIPTION
To make sure we are able to send metrics from all branches this PR adds support of using GitHub context for 'push' events. 

With these changes, it's allowed to use the action on push events without having comments and annotation. It still consider Pull_request context more important and will use data from there to compare coverage in PR basics
