### PR TITLE
fix: respect `barecheck-api-token` value from config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         uses: ./
         with:
           barecheck-github-app-token: ${{ secrets.BARECHECK_GITHUB_APP_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # github-token: ${{ secrets.GITHUB_TOKEN }}
           # barecheck-api-key: ${{ secrets.BARECHECK_API_KEY }}
           lcov-file: "./coverage/lcov.info"
           minimum-ratio: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           barecheck-github-app-token: ${{ secrets.BARECHECK_GITHUB_APP_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          barecheck-api-key: ${{ secrets.BARECHECK_API_KEY }}
+          # barecheck-api-key: ${{ secrets.BARECHECK_API_KEY }}
           lcov-file: "./coverage/lcov.info"
           minimum-ratio: 0
           send-summary-comment: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           barecheck-github-app-token: ${{ secrets.BARECHECK_GITHUB_APP_TOKEN }}
           # github-token: ${{ secrets.GITHUB_TOKEN }}
-          # barecheck-api-key: ${{ secrets.BARECHECK_API_KEY }}
+          barecheck-api-key: ${{ secrets.BARECHECK_API_KEY }}
           lcov-file: "./coverage/lcov.info"
           minimum-ratio: 0
           send-summary-comment: true

--- a/dist/index.js
+++ b/dist/index.js
@@ -13400,6 +13400,8 @@ const { getBaseBranchCoverage } = __nccwpck_require__(2069);
 // eslint-disable-next-line max-statements
 const getBasecoverageDiff = async (coverage) => {
   const baseFile = getBaseLcovFile();
+  // eslint-disable-next-line no-console
+  console.log(getBarecheckApiKey());
   const baseMetrics = getBarecheckApiKey()
     ? await getBaseBranchCoverage()
     : false;

--- a/dist/index.js
+++ b/dist/index.js
@@ -13400,8 +13400,7 @@ const { getBaseBranchCoverage } = __nccwpck_require__(2069);
 // eslint-disable-next-line max-statements
 const getBasecoverageDiff = async (coverage) => {
   const baseFile = getBaseLcovFile();
-  // eslint-disable-next-line no-console
-  console.log(getBarecheckApiKey());
+
   const baseMetrics = getBarecheckApiKey()
     ? await getBaseBranchCoverage()
     : false;
@@ -13755,7 +13754,7 @@ const core = __nccwpck_require__(2186);
 
 const { parseLcovFile } = __nccwpck_require__(5396);
 
-const { getLcovFile } = __nccwpck_require__(6);
+const { getLcovFile, getBarecheckApiKey } = __nccwpck_require__(6);
 
 const { sendCurrentCoverage } = __nccwpck_require__(2069);
 
@@ -13774,7 +13773,8 @@ const runCodeCoverage = async (coverage) => {
 
   await checkMinimumRatio(diff);
   await showAnnotations(changedFilesCoverage);
-  await sendCurrentCoverage(coverage.percentage);
+
+  if (getBarecheckApiKey()) await sendCurrentCoverage(coverage.percentage);
 
   core.setOutput("percentage", coverage.percentage);
   core.setOutput("diff", diff);

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ const core = require("@actions/core");
 
 const { parseLcovFile } = require("@barecheck/core");
 
-const { getLcovFile } = require("./input");
+const { getLcovFile, getBarecheckApiKey } = require("./input");
 
 const { sendCurrentCoverage } = require("./lib/api");
 
@@ -21,7 +21,8 @@ const runCodeCoverage = async (coverage) => {
 
   await checkMinimumRatio(diff);
   await showAnnotations(changedFilesCoverage);
-  await sendCurrentCoverage(coverage.percentage);
+
+  if (getBarecheckApiKey()) await sendCurrentCoverage(coverage.percentage);
 
   core.setOutput("percentage", coverage.percentage);
   core.setOutput("diff", diff);

--- a/src/services/baseCoverageDiff.js
+++ b/src/services/baseCoverageDiff.js
@@ -7,6 +7,8 @@ const { getBaseBranchCoverage } = require("../lib/api");
 // eslint-disable-next-line max-statements
 const getBasecoverageDiff = async (coverage) => {
   const baseFile = getBaseLcovFile();
+  // eslint-disable-next-line no-console
+  console.log(getBarecheckApiKey());
   const baseMetrics = getBarecheckApiKey()
     ? await getBaseBranchCoverage()
     : false;

--- a/src/services/baseCoverageDiff.js
+++ b/src/services/baseCoverageDiff.js
@@ -7,8 +7,7 @@ const { getBaseBranchCoverage } = require("../lib/api");
 // eslint-disable-next-line max-statements
 const getBasecoverageDiff = async (coverage) => {
   const baseFile = getBaseLcovFile();
-  // eslint-disable-next-line no-console
-  console.log(getBarecheckApiKey());
+
   const baseMetrics = getBarecheckApiKey()
     ? await getBaseBranchCoverage()
     : false;


### PR DESCRIPTION
Fixing issue with action when API TOKEN is not passed. 

API_TOKEN is not required and we always be able to run barecheck code coverage action without any requirements of the cloud. 

Everyone is able to compare coverage with another file or just value previously stored by using Barecheck cloud.