### PR TITLE
feat: add `workspace-path` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To integrate with this Github Action, you can just use the following configurati
 | `show-annotations`           | **no**   | 'warning'   | Option to enable Github annotation that would show uncovered files in review tab. Options: ' ' \| warning \| error                                   |
 | `minimum-ratio`              | **no**   | ''          | Percentage of uncovered lines that are allowed for new changes                                                                                       |
 | `app-name`                   | **no**   | 'Barecheck' | Application name would be used once you have more than one report in your workflow and want to have different reports per application.               |
-
+| `workspace-path`             | **no**   | 'Barecheck' | Option to specify the path of projects in monorepo                |
 ## Workflow Example
 
 In order to compare your new changes report and the base branch you are able to use Github artifacts as in the example below:
@@ -137,6 +137,7 @@ If you have monorepo with more than one application and want to have different c
     lcov-file: "./coverage/lcov.info"
     base-lcov-file: "./coverage/base-lcov.info"
     app-name: "Application 1"
+    workspace-path: "apps/application1"
 ```
 
 ```yml
@@ -148,6 +149,7 @@ If you have monorepo with more than one application and want to have different c
     lcov-file: "./coverage/lcov.info"
     base-lcov-file: "./coverage/base-lcov.info"
     app-name: "Application 2"
+    workspace-path: "apps/application2"
 ```
 
 ### Using Barecheck Cloud

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ To integrate with this Github Action, you can just use the following configurati
 | `show-annotations`           | **no**   | 'warning'   | Option to enable Github annotation that would show uncovered files in review tab. Options: ' ' \| warning \| error                                   |
 | `minimum-ratio`              | **no**   | ''          | Percentage of uncovered lines that are allowed for new changes                                                                                       |
 | `app-name`                   | **no**   | 'Barecheck' | Application name would be used once you have more than one report in your workflow and want to have different reports per application.               |
-| `workspace-path`             | **no**   | 'Barecheck' | Option to specify the path of projects in monorepo                |
+| `workspace-path`             | **no**   | 'Barecheck' | Option to specify the path of projects in monorepo                                                                                                   |
+
 ## Workflow Example
 
 In order to compare your new changes report and the base branch you are able to use Github artifacts as in the example below:

--- a/dist/index.js
+++ b/dist/index.js
@@ -14433,6 +14433,8 @@ const getBaseLcovFile = () => valueOrFalse(core.getInput("base-lcov-file"));
 const getSendSummaryComment = () =>
   valueOrFalse(core.getInput("send-summary-comment"));
 
+const getWorkspacePath = () => core.getInput("workspace-path");
+
 module.exports = {
   getShowAnnotations,
   getGithubToken,
@@ -14441,7 +14443,8 @@ module.exports = {
   getAppName,
   getLcovFile,
   getBaseLcovFile,
-  getSendSummaryComment
+  getSendSummaryComment,
+  getWorkspacePath
 };
 
 
@@ -14635,8 +14638,10 @@ module.exports = getBasecoverageDiff;
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const { githubApi } = __nccwpck_require__(5396);
+const path = __nccwpck_require__(1017);
 
 const { getPullRequestContext, getOctokit } = __nccwpck_require__(8383);
+const { getWorkspacePath } = __nccwpck_require__(6);
 
 const getChangedFilesCoverage = async (coverage) => {
   const pullRequestContext = getPullRequestContext();
@@ -14652,17 +14657,19 @@ const getChangedFilesCoverage = async (coverage) => {
     pullNumber
   });
 
+  const workspacePath = getWorkspacePath();
   const changedFilesCoverage = coverage.data.reduce(
     (allFiles, { file, lines }) => {
+      const filePath = workspacePath ? path.join(workspacePath, file) : file;
       const changedFile = changedFiles.find(
-        ({ filename }) => filename === file
+        ({ filename }) => filename === filePath
       );
 
       if (changedFile) {
         return [
           ...allFiles,
           {
-            file,
+            file: filePath,
             url: changedFile.blob_url,
             lines
           }

--- a/src/input.js
+++ b/src/input.js
@@ -38,6 +38,8 @@ const getBaseLcovFile = () => valueOrFalse(core.getInput("base-lcov-file"));
 const getSendSummaryComment = () =>
   valueOrFalse(core.getInput("send-summary-comment"));
 
+const getWorkspacePath = () => core.getInput("workspace-path");
+
 module.exports = {
   getShowAnnotations,
   getGithubToken,
@@ -46,5 +48,6 @@ module.exports = {
   getAppName,
   getLcovFile,
   getBaseLcovFile,
-  getSendSummaryComment
+  getSendSummaryComment,
+  getWorkspacePath
 };

--- a/src/services/changedFilesCoverage.js
+++ b/src/services/changedFilesCoverage.js
@@ -22,7 +22,7 @@ const getChangedFilesCoverage = async (coverage) => {
   const changedFilesCoverage = coverage.data.reduce(
     (allFiles, { file, lines }) => {
       const filePath = workspacePath ? path.join(workspacePath, file) : file;
-      console.log(filePath);
+
       const changedFile = changedFiles.find(
         ({ filename }) => filename === filePath
       );

--- a/src/services/changedFilesCoverage.js
+++ b/src/services/changedFilesCoverage.js
@@ -1,4 +1,5 @@
 const { githubApi } = require("@barecheck/core");
+const path = require("path");
 
 const { getPullRequestContext, getOctokit } = require("../lib/github");
 const { getWorkspacePath } = require("../input");
@@ -20,7 +21,7 @@ const getChangedFilesCoverage = async (coverage) => {
   const workspacePath = getWorkspacePath();
   const changedFilesCoverage = coverage.data.reduce(
     (allFiles, { file, lines }) => {
-      const filePath = workspacePath ? `${workspacePath}/${file}` : file;
+      const filePath = workspacePath ? path.join(workspacePath, file) : file;
       const changedFile = changedFiles.find(
         ({ filename }) => filename === filePath
       );

--- a/src/services/changedFilesCoverage.js
+++ b/src/services/changedFilesCoverage.js
@@ -22,6 +22,7 @@ const getChangedFilesCoverage = async (coverage) => {
   const changedFilesCoverage = coverage.data.reduce(
     (allFiles, { file, lines }) => {
       const filePath = workspacePath ? path.join(workspacePath, file) : file;
+      console.log(filePath);
       const changedFile = changedFiles.find(
         ({ filename }) => filename === filePath
       );

--- a/src/services/changedFilesCoverage.js
+++ b/src/services/changedFilesCoverage.js
@@ -1,6 +1,7 @@
 const { githubApi } = require("@barecheck/core");
 
 const { getPullRequestContext, getOctokit } = require("../lib/github");
+const { getWorkspacePath } = require("../input");
 
 const getChangedFilesCoverage = async (coverage) => {
   const pullRequestContext = getPullRequestContext();
@@ -16,17 +17,19 @@ const getChangedFilesCoverage = async (coverage) => {
     pullNumber
   });
 
+  const workspacePath = getWorkspacePath();
   const changedFilesCoverage = coverage.data.reduce(
     (allFiles, { file, lines }) => {
+      const filePath = workspacePath ? `${workspacePath}/${file}` : file;
       const changedFile = changedFiles.find(
-        ({ filename }) => filename === file
+        ({ filename }) => filename === filePath
       );
 
       if (changedFile) {
         return [
           ...allFiles,
           {
-            file,
+            file: filePath,
             url: changedFile.blob_url,
             lines
           }


### PR DESCRIPTION
Fix issue in generating coverage report for monorepo. https://github.com/barecheck/code-coverage-action/issues/235