### PR TITLE
feat(floats): support floats as the minimum ratio

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -14695,7 +14695,7 @@ module.exports = getChangedFilesCoverage;
 const core = __nccwpck_require__(2186);
 
 const checkMinimumRatio = (coverageDiff) => {
-  const minCoverageRatio = parseInt(core.getInput("minimum-ratio"), 10);
+  const minCoverageRatio = parseFloat(core.getInput("minimum-ratio"));
 
   core.info(`minimum-ratio: ${minCoverageRatio}`);
 

--- a/src/services/minimumRatio.js
+++ b/src/services/minimumRatio.js
@@ -1,7 +1,7 @@
 const core = require("@actions/core");
 
 const checkMinimumRatio = (coverageDiff) => {
-  const minCoverageRatio = parseInt(core.getInput("minimum-ratio"), 10);
+  const minCoverageRatio = parseFloat(core.getInput("minimum-ratio"));
 
   core.info(`minimum-ratio: ${minCoverageRatio}`);
 

--- a/test/services/minimumRatio.test.js
+++ b/test/services/minimumRatio.test.js
@@ -98,5 +98,49 @@ describe("services/minCoverageRatio", () => {
       assert.isUndefined(res);
       assert.isFalse(setFailed.calledOnce);
     });
+
+    it("Supports floats as the ratio, with an acceptable diff amount", () => {
+      const minCoverageRatio = 0.5;
+      const coverageDiff = "-0.45";
+
+      const getInput = sinon
+        .stub()
+        .withArgs("minimum-ratio")
+        .returns(minCoverageRatio);
+
+      const setFailed = sinon.spy();
+
+      const checkMinimumRatio = minCoverageRatioMock({
+        getInput,
+        setFailed
+      });
+
+      const res = checkMinimumRatio(coverageDiff);
+
+      assert.isUndefined(res);
+      assert.isFalse(setFailed.calledOnce);
+    })
+
+    it("Supports floats as the ratio, with an unacceptable diff amount", () => {
+      const minCoverageRatio = 0.5;
+      const coverageDiff = "-0.51";
+
+      const getInput = sinon
+        .stub()
+        .withArgs("minimum-ratio")
+        .returns(minCoverageRatio);
+
+      const setFailed = sinon.spy();
+
+      const checkMinimumRatio = minCoverageRatioMock({
+        getInput,
+        setFailed
+      });
+
+      const res = checkMinimumRatio(coverageDiff);
+
+      assert.isUndefined(res);
+      assert.isTrue(setFailed.calledOnce);
+    })
   });
 });


### PR DESCRIPTION
Support a float as the minimumRatio value. In our codebases, the minimum value we can use now is 1%, and that is too high off a difference for us. We would like to support a minimum ratio of something like 0.2%.