### PR TITLE
feat: explicit 'pull-number' input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,8 @@ branding:
 inputs:
   github-token:
     description: Your GitHub Action token
-    required: true
+    required: false
+    default: ''
   barecheck-github-app-token:
     description: Barecheck application token, received after application installation. Would be used instead of `github-token`
     required: false

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,10 @@ inputs:
     description: "Path to your application. Mostly used for Monorepos if you need to add prefix for all files"
     default: ""
     required: false
+  pull-number:
+    description: "Pull request number (Optional). For use in non-'pull_request' events"
+    default: ""
+    required: false
 
 outputs:
   percentage:

--- a/dist/index.js
+++ b/dist/index.js
@@ -14439,7 +14439,7 @@ const getPullNumber = () => {
   const rawValue = core.getInput("pull-number");
   const intValue = parseInt(rawValue, 10);
   const isNumber = !isNaN(intValue);
-  return (isNumber && intValue > 0);
+  return isNumber && intValue > 0 ? intValue : false;
 }
 
 module.exports = {

--- a/dist/index.js
+++ b/dist/index.js
@@ -14438,9 +14438,9 @@ const getWorkspacePath = () => core.getInput("workspace-path");
 const getPullNumber = () => {
   const rawValue = core.getInput("pull-number");
   const intValue = parseInt(rawValue, 10);
-  const isNumber = !isNaN(intValue);
+  const isNumber = !Number.isNaN(intValue);
   return isNumber && intValue > 0 ? intValue : false;
-}
+};
 
 module.exports = {
   getShowAnnotations,
@@ -14540,7 +14540,11 @@ module.exports = {
 const github = __nccwpck_require__(5438);
 const { githubApi } = __nccwpck_require__(5396);
 
-const { getBarecheckGithubAppToken, getGithubToken, getPullNumber } = __nccwpck_require__(6);
+const {
+  getBarecheckGithubAppToken,
+  getGithubToken,
+  getPullNumber
+} = __nccwpck_require__(6);
 
 let octokit = null;
 
@@ -14553,7 +14557,8 @@ const getPullRequestContext = () => {
 
   const { owner, repo } = github.context.repo;
 
-  const pullNumber = pullNumberInput || github.context.payload.pull_request.number;
+  const pullNumber =
+    pullNumberInput || github.context.payload.pull_request.number;
 
   return {
     owner,

--- a/src/input.js
+++ b/src/input.js
@@ -43,9 +43,9 @@ const getWorkspacePath = () => core.getInput("workspace-path");
 const getPullNumber = () => {
   const rawValue = core.getInput("pull-number");
   const intValue = parseInt(rawValue, 10);
-  const isNumber = !isNaN(intValue);
+  const isNumber = !Number.isNaN(intValue);
   return isNumber && intValue > 0 ? intValue : false;
-}
+};
 
 module.exports = {
   getShowAnnotations,

--- a/src/input.js
+++ b/src/input.js
@@ -44,7 +44,7 @@ const getPullNumber = () => {
   const rawValue = core.getInput("pull-number");
   const intValue = parseInt(rawValue, 10);
   const isNumber = !isNaN(intValue);
-  return (isNumber && intValue > 0);
+  return isNumber && intValue > 0 ? intValue : false;
 }
 
 module.exports = {

--- a/src/input.js
+++ b/src/input.js
@@ -40,6 +40,13 @@ const getSendSummaryComment = () =>
 
 const getWorkspacePath = () => core.getInput("workspace-path");
 
+const getPullNumber = () => {
+  const rawValue = core.getInput("pull-number");
+  const intValue = parseInt(rawValue, 10);
+  const isNumber = !isNaN(intValue);
+  return (isNumber && intValue > 0);
+}
+
 module.exports = {
   getShowAnnotations,
   getGithubToken,
@@ -49,5 +56,6 @@ module.exports = {
   getLcovFile,
   getBaseLcovFile,
   getSendSummaryComment,
-  getWorkspacePath
+  getWorkspacePath,
+  getPullNumber
 };

--- a/src/lib/github.js
+++ b/src/lib/github.js
@@ -1,18 +1,20 @@
 const github = require("@actions/github");
 const { githubApi } = require("@barecheck/core");
 
-const { getBarecheckGithubAppToken, getGithubToken } = require("../input");
+const { getBarecheckGithubAppToken, getGithubToken, getPullNumber } = require("../input");
 
 let octokit = null;
 
 const cleanRef = (fullRef) => fullRef.replace("refs/heads/", "");
 
 const getPullRequestContext = () => {
-  if (!github.context.payload.pull_request) return false;
+  const pullNumberInput = getPullNumber();
+
+  if (!github.context.payload.pull_request && !pullNumberInput) return false;
 
   const { owner, repo } = github.context.repo;
 
-  const pullNumber = github.context.payload.pull_request.number;
+  const pullNumber = pullNumberInput || github.context.payload.pull_request.number;
 
   return {
     owner,

--- a/src/lib/github.js
+++ b/src/lib/github.js
@@ -1,7 +1,11 @@
 const github = require("@actions/github");
 const { githubApi } = require("@barecheck/core");
 
-const { getBarecheckGithubAppToken, getGithubToken, getPullNumber } = require("../input");
+const {
+  getBarecheckGithubAppToken,
+  getGithubToken,
+  getPullNumber
+} = require("../input");
 
 let octokit = null;
 
@@ -14,7 +18,8 @@ const getPullRequestContext = () => {
 
   const { owner, repo } = github.context.repo;
 
-  const pullNumber = pullNumberInput || github.context.payload.pull_request.number;
+  const pullNumber =
+    pullNumberInput || github.context.payload.pull_request.number;
 
   return {
     owner,

--- a/test/input.test.js
+++ b/test/input.test.js
@@ -153,7 +153,7 @@ describe("input", () => {
       { input: "0", expected: false },
       { input: "1", expected: 1 },
       { input: "2", expected: 2 },
-      { input: "44", expected: 44 },
+      { input: "44", expected: 44 }
     ].forEach(({ input, expected }) =>
       it(`should return ${expected} when 'pull-number=${input}'`, () => {
         const expectedRes = input;

--- a/test/input.test.js
+++ b/test/input.test.js
@@ -151,9 +151,11 @@ describe("input", () => {
       { input: "", expected: false },
       { input: "-1", expected: false },
       { input: "0", expected: false },
-      { input: "1", expected: true },
+      { input: "1", expected: 1 },
+      { input: "2", expected: 2 },
+      { input: "44", expected: 44 },
     ].forEach(({ input, expected }) =>
-      it(`should return ${expected} when  'pull-number=${input}'`, () => {
+      it(`should return ${expected} when 'pull-number=${input}'`, () => {
         const expectedRes = input;
         const getInput = sinon
           .stub()

--- a/test/input.test.js
+++ b/test/input.test.js
@@ -144,4 +144,28 @@ describe("input", () => {
       })
     );
   });
+
+  describe("getPullNumber", () => {
+    [
+      { input: "foo", expected: false },
+      { input: "", expected: false },
+      { input: "-1", expected: false },
+      { input: "0", expected: false },
+      { input: "1", expected: true },
+    ].forEach(({ input, expected }) =>
+      it(`should return ${expected} when  'pull-number=${input}'`, () => {
+        const expectedRes = input;
+        const getInput = sinon
+          .stub()
+          .withArgs("pull-number")
+          .returns(expectedRes);
+
+        const { getPullNumber } = inputMock({ getInput });
+
+        const res = getPullNumber(input);
+
+        assert.equal(res, expected);
+      })
+    );
+  });
 });

--- a/test/lib/github.test.js
+++ b/test/lib/github.test.js
@@ -3,7 +3,7 @@ const sinon = require("sinon");
 const { assert } = require("chai");
 
 const actionsCoreStub = require("../stubs/actionsCore.stub");
-const { getPullNumber } = require('../../src/input');
+// const { getPullNumber } = require('../../src/input');
 
 const defaultMocks = {
   ...actionsCoreStub,
@@ -15,14 +15,24 @@ const defaultMocks = {
 };
 
 const getGitHubLibMock = (mocks) => {
-  const { github, githubApi, getBarecheckGithubAppToken, getGithubToken, getPullNumber } = {
+  const {
+    github,
+    githubApi,
+    getBarecheckGithubAppToken,
+    getGithubToken,
+    getPullNumber
+  } = {
     ...defaultMocks,
     ...mocks
   };
   return proxyquire("../../src/lib/github", {
     "@actions/github": github,
     "@barecheck/core": { githubApi },
-    "../input": { getBarecheckGithubAppToken, getGithubToken, getPullNumber }
+    "../input": {
+      getBarecheckGithubAppToken,
+      getGithubToken,
+      getPullNumber
+    }
   });
 };
 
@@ -81,7 +91,10 @@ describe("lib/github", () => {
         }
       };
       const getPullNumber = sinon.stub().returns(321);
-      const { getPullRequestContext } = getGitHubLibMock({ getPullNumber, github });
+      const { getPullRequestContext } = getGitHubLibMock({
+        getPullNumber,
+        github
+      });
 
       const pullRequestContext = getPullRequestContext();
 
@@ -107,7 +120,10 @@ describe("lib/github", () => {
         }
       };
       const getPullNumber = sinon.stub().returns(321);
-      const { getPullRequestContext } = getGitHubLibMock({ getPullNumber, github });
+      const { getPullRequestContext } = getGitHubLibMock({
+        getPullNumber,
+        github
+      });
 
       const pullRequestContext = getPullRequestContext();
 


### PR DESCRIPTION
The current implementation is painful for us because of the hard dependency on the `pull_request` context.

This pain comes more from GitHub Actions cache access. I.e. we cannot simply retrieve the lcov file in a convenient way as created in our feature branch `push` event, from a separate `pull_request` event workflow.

This change allows us to use an Action like these:

- https://github.com/marketplace/actions/find-current-pull-request
- https://github.com/marketplace/actions/find-pull-request

to explicitly target our PR on `push` events and make use of the `send-summary-comment` input.
